### PR TITLE
[FEAT]: redis-preload

### DIFF
--- a/src/main/java/com/chat/chat/common/util/RedisDataLoader.java
+++ b/src/main/java/com/chat/chat/common/util/RedisDataLoader.java
@@ -2,11 +2,11 @@ package com.chat.chat.common.util;
 
 import com.chat.chat.entity.Member;
 import com.chat.chat.entity.Room;
+import com.chat.chat.repository.RedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
-import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 
@@ -16,7 +16,7 @@ import reactor.core.publisher.Flux;
  * -> 대책으로 서버로드시 "미리로드"하는 preloading 을 사용
  * <p>
  * 2. webflux 비동기 = redis 에서도 비동기 사용
- * -> ReactiveRedisTemplate 사용
+ * -> ReactiveRedisTemplate
  * -> Mongo 에서 가져오는 데이터 여러개 = flux
  * <p>
  * 3.저장할 데이터
@@ -32,23 +32,25 @@ import reactor.core.publisher.Flux;
 @RequiredArgsConstructor
 public class RedisDataLoader {
 
-    private final ReactiveRedisTemplate<String, String> redisTemplate;
+    private final RedisRepository redisRepository;
     private final ReactiveMongoTemplate mongoTemplate;
 
     @Bean
     public ApplicationRunner loadDataToRedisBeforeServerStart() {
         return args -> {
+
             Flux<Member> members = mongoTemplate.findAll(Member.class);
 
             members.subscribe(member -> {
-                redisTemplate.opsForValue().set("memberId:" + member.getId(), member.getMemberId()).subscribe();
-                redisTemplate.opsForValue().set("memberPw:" + member.getId(), member.getMemberPassword()).subscribe();
+                redisRepository.save("memberId:" + member.getMemberId(), member.getMemberId()).subscribe();
+                redisRepository.save("memberPw:" + member.getMemberId(), member.getMemberPassword()).subscribe();
             });
+
 
             Flux<Room> rooms = mongoTemplate.findAll(Room.class);
 
             rooms.subscribe(room -> {
-                redisTemplate.opsForValue().set("roomName:" + room.getId(), room.getRoomName()).subscribe();
+                redisRepository.save("roomName:" + room.getRoomName(), room.getRoomName()).subscribe();
             });
 
             System.out.println("Redis Load Complete!");

--- a/src/main/java/com/chat/chat/common/util/RedisDataLoader.java
+++ b/src/main/java/com/chat/chat/common/util/RedisDataLoader.java
@@ -1,0 +1,57 @@
+package com.chat.chat.common.util;
+
+import com.chat.chat.entity.Member;
+import com.chat.chat.entity.Room;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+/**
+ * redis 구현시 고려사항
+ *  1. in-memory 라서 서버가 꺼지면 안에 데이터가 사라짐
+ * -> 대책으로 서버로드시 "미리로드"하는 preloading 을 사용
+ * <p>
+ * 2. webflux 비동기 = redis 에서도 비동기 사용
+ * -> ReactiveRedisTemplate 사용
+ * -> Mongo 에서 가져오는 데이터 여러개 = flux
+ * <p>
+ * 3.저장할 데이터
+ * Key       ||  Value
+ * memberId  ||  seodonghee     ----  (String)
+ * memberPw  ||  hashpw(memberPw) --- (String)
+ * roomName  ||  실제 방이름 ---(String)
+ *
+ * 4.추가구현사항
+ * 블랙리스트 토큰 관련
+ */
+@Component
+@RequiredArgsConstructor
+public class RedisDataLoader {
+
+    private final ReactiveRedisTemplate<String, String> redisTemplate;
+    private final ReactiveMongoTemplate mongoTemplate;
+
+    @Bean
+    public ApplicationRunner loadDataToRedisBeforeServerStart() {
+        return args -> {
+            Flux<Member> members = mongoTemplate.findAll(Member.class);
+
+            members.subscribe(member -> {
+                redisTemplate.opsForValue().set("memberId:" + member.getId(), member.getMemberId()).subscribe();
+                redisTemplate.opsForValue().set("memberPw:" + member.getId(), member.getMemberPassword()).subscribe();
+            });
+
+            Flux<Room> rooms = mongoTemplate.findAll(Room.class);
+
+            rooms.subscribe(room -> {
+                redisTemplate.opsForValue().set("roomName:" + room.getId(), room.getRoomName()).subscribe();
+            });
+
+            System.out.println("Redis Load Complete!");
+        };
+    }
+}

--- a/src/main/java/com/chat/chat/repository/RedisRepository.java
+++ b/src/main/java/com/chat/chat/repository/RedisRepository.java
@@ -1,0 +1,60 @@
+package com.chat.chat.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * redis 도
+ * repository 처럼 crud 작업을 추상화해서
+ * 비지니스 로직 단계에서 직접 redis로직을 수행하지 않고 , 모듈화된 로직으로 접근하는 것이 목표
+ * 재사용이 목표
+ * <p>
+ * 1. 저장 -> Mono
+ * => key는 mongo에서 생성되고 가져와야함
+ * 2. 찾기 key(id) 값으로  -> Mono
+ * 3. 삭제 -> Mono // delete 는 기본적으로 Mono(Long) 반환 .. Boolean으로 바꿔야함
+ * 4. key 값 매칭 전부 반환 -> Flux
+ * 5. Key(id) 값을 토대로 수정 -> Mono ... redis 는 update 가 없음 ,,set 으로 덮어야
+ * 6. exist 여부도 넣는 경우를 봤는데 .. 2번째 기능과 겹칠것 같아서 추상화하지 않음
+ * 이라고 생각했지만 만약에 수정할 경우에 존재여부를 확인해야할거같다
+ */
+
+
+@Repository
+@RequiredArgsConstructor
+public class RedisRepository {
+
+    private final ReactiveRedisTemplate<String, String> redisTemplate;
+
+
+    public Mono<Boolean> save(String key, String value) {
+        return redisTemplate.opsForValue().set(key, value);
+    }
+
+    public Mono<String> findByKey(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public Mono<Boolean> delete(String key) {
+        return redisTemplate.delete(key).hasElement();
+    }
+
+    public Flux<String> findAllRooms() {
+        return redisTemplate.keys("roomName*")
+                .flatMap(redisTemplate.opsForValue()::get);
+    }
+
+
+    public Mono<Boolean> update(String key, String newValue) {
+        return redisTemplate.opsForValue().set(key, newValue);
+    }
+
+    public Mono<Boolean> exists(String key) {
+        return redisTemplate.hasKey(key);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,8 +6,8 @@ spring:
 
   cache:
     type: redis
-    host:
-    post:
+    host: localhost
+    post: 6379
     password:
 
 


### PR DESCRIPTION
* redis 구현시 고려사항
 *  1. in-memory 라서 서버가 꺼지면 안에 데이터가 사라짐
 * -> 대책으로 서버로드시 "미리로드"하는 preloading 을 사용
 * <p>
 * 2. webflux 비동기 = redis 에서도 비동기 사용
 * -> ReactiveRedisTemplate 사용
 * -> Mongo 에서 가져오는 데이터 여러개 = flux
 * <p>
 * 3. 저장할 데이터
 * Key       ||  Value
 * memberId  ||  seodonghee     ----  (String)
 * memberPw  ||  hashpw(memberPw) --- (String)
 * roomName  ||  실제 방이름 ---(String)
 *
 * 4. 추가구현사항
 * 블랙리스트 토큰 관련
 */
 
 -----------------------------------
 /**
 * redis 도
 * repository 처럼 crud 작업을 추상화해서
 * 비지니스 로직 단계에서 직접 redis로직을 수행하지 않고 , 모듈화된 로직으로 접근하는 것이 목표
 * 재사용이 목표
 * <p>
 * 1. 저장 -> Mono
 * => key는 mongo에서 생성되고 가져와야함
 * 2. 찾기 key(id) 값으로  -> Mono
 * 3. 삭제 -> Mono // delete 는 기본적으로 Mono(Long) 반환 .. Boolean으로 바꿔야함
 * 4. key 값 매칭 전부 반환 -> Flux
 * 5. Key(id) 값을 토대로 수정 -> Mono ... redis 는 update 가 없음 ,,set 으로 덮어야
 * 6. exist 여부도 넣는 경우를 봤는데 .. 2번째 기능과 겹칠것 같아서 추상화하지 않음
 * 이라고 생각했지만 만약에 수정할 경우에 존재여부를 확인해야할거같다
 */

 
<img width="1153" alt="스크린샷 2024-12-27 오전 9 50 40" src="https://github.com/user-attachments/assets/3ea10595-2495-4bd6-99fc-058d3050f449" />

 